### PR TITLE
geom_alt props

### DIFF
--- a/data/421/168/983/421168983.geojson
+++ b/data/421/168/983/421168983.geojson
@@ -582,6 +582,9 @@
     },
     "wof:country":"BF",
     "wof:created":1459008789,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cc7be77c5e673a03e9410f74d1f69e1",
     "wof:hierarchy":[
         {
@@ -593,7 +596,7 @@
         }
     ],
     "wof:id":421168983,
-    "wof:lastmodified":1566613290,
+    "wof:lastmodified":1582344679,
     "wof:name":"Ouagadougou",
     "wof:parent_id":421187907,
     "wof:placetype":"locality",

--- a/data/421/187/907/421187907.geojson
+++ b/data/421/187/907/421187907.geojson
@@ -233,6 +233,9 @@
     },
     "wof:country":"BF",
     "wof:created":1459009527,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9cef97d75cc3c35a5ae6831f91d5f849",
     "wof:hierarchy":[
         {
@@ -243,7 +246,7 @@
         }
     ],
     "wof:id":421187907,
-    "wof:lastmodified":1566613292,
+    "wof:lastmodified":1582344679,
     "wof:name":"Kadiogo",
     "wof:parent_id":1108805693,
     "wof:placetype":"county",

--- a/data/856/322/13/85632213.geojson
+++ b/data/856/322/13/85632213.geojson
@@ -956,7 +956,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1010,6 +1011,11 @@
     },
     "wof:country":"BF",
     "wof:country_alpha3":"BFA",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"c484be2a30abb49ac48eebc61ecaa704",
     "wof:hierarchy":[
         {
@@ -1024,7 +1030,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566612768,
+    "wof:lastmodified":1582344671,
     "wof:name":"Burkina Faso",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/322/13/85632213.geojson
+++ b/data/856/322/13/85632213.geojson
@@ -956,8 +956,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1030,7 +1029,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1582344671,
+    "wof:lastmodified":1583223554,
     "wof:name":"Burkina Faso",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/858/022/53/85802253.geojson
+++ b/data/858/022/53/85802253.geojson
@@ -68,6 +68,9 @@
         "gp:id":1464570
     },
     "wof:country":"BF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"365eabac1b1dd1b6d1cc45947770825c",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566612769,
+    "wof:lastmodified":1582344671,
     "wof:name":"Zone Pilote de Sissen",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/413/143/890413143.geojson
+++ b/data/890/413/143/890413143.geojson
@@ -209,6 +209,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050989,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ade2c00f14d6eba463af26c25e69f084",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
         }
     ],
     "wof:id":890413143,
-    "wof:lastmodified":1566613299,
+    "wof:lastmodified":1582344681,
     "wof:name":"Namentenga",
     "wof:parent_id":1108805709,
     "wof:placetype":"county",

--- a/data/890/413/145/890413145.geojson
+++ b/data/890/413/145/890413145.geojson
@@ -199,6 +199,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d523c6420d922c4b28535e569e8aa15d",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":890413145,
-    "wof:lastmodified":1566613298,
+    "wof:lastmodified":1582344681,
     "wof:name":"S\u00e9no",
     "wof:parent_id":1108805689,
     "wof:placetype":"county",

--- a/data/890/413/147/890413147.geojson
+++ b/data/890/413/147/890413147.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c30adcbc98e09ac33c8c81d5d0ba5b7e",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":890413147,
-    "wof:lastmodified":1566613300,
+    "wof:lastmodified":1582344681,
     "wof:name":"Sanmatenga",
     "wof:parent_id":1108805709,
     "wof:placetype":"county",

--- a/data/890/413/149/890413149.geojson
+++ b/data/890/413/149/890413149.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c57bc9d0a1fc5aab238613f6062738a",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":890413149,
-    "wof:lastmodified":1566613300,
+    "wof:lastmodified":1582344681,
     "wof:name":"Sangui\u00e9",
     "wof:parent_id":1108805695,
     "wof:placetype":"county",

--- a/data/890/413/151/890413151.geojson
+++ b/data/890/413/151/890413151.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17e7db25b53e186951c2cf9ecef78b5e",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":890413151,
-    "wof:lastmodified":1566613298,
+    "wof:lastmodified":1582344681,
     "wof:name":"Poni",
     "wof:parent_id":1108805683,
     "wof:placetype":"county",

--- a/data/890/413/153/890413153.geojson
+++ b/data/890/413/153/890413153.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"617a5b5caff74b38009d4f18cd26afc9",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":890413153,
-    "wof:lastmodified":1566613299,
+    "wof:lastmodified":1582344681,
     "wof:name":"Oudalan",
     "wof:parent_id":1108805689,
     "wof:placetype":"county",

--- a/data/890/413/157/890413157.geojson
+++ b/data/890/413/157/890413157.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8fc2e0786db157f5533fb30a740c496b",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":890413157,
-    "wof:lastmodified":1566613296,
+    "wof:lastmodified":1582344680,
     "wof:name":"Oubritenga",
     "wof:parent_id":1108805691,
     "wof:placetype":"county",

--- a/data/890/413/159/890413159.geojson
+++ b/data/890/413/159/890413159.geojson
@@ -212,6 +212,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5dd64b995f622777aa87170b78a8c04",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":890413159,
-    "wof:lastmodified":1566613297,
+    "wof:lastmodified":1582344680,
     "wof:name":"Nahouri",
     "wof:parent_id":1108805699,
     "wof:placetype":"county",

--- a/data/890/413/161/890413161.geojson
+++ b/data/890/413/161/890413161.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf6d22339d294e3d6291b35b8834366b",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":890413161,
-    "wof:lastmodified":1566613297,
+    "wof:lastmodified":1582344680,
     "wof:name":"Mouhoun",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",

--- a/data/890/413/163/890413163.geojson
+++ b/data/890/413/163/890413163.geojson
@@ -211,6 +211,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aaec7996845bd94830c10ac8f488c98b",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":890413163,
-    "wof:lastmodified":1566613299,
+    "wof:lastmodified":1582344681,
     "wof:name":"Kouritenga",
     "wof:parent_id":1108805705,
     "wof:placetype":"county",

--- a/data/890/413/165/890413165.geojson
+++ b/data/890/413/165/890413165.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"75852d046a72ad9c9286507910d39573",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":890413165,
-    "wof:lastmodified":1566613299,
+    "wof:lastmodified":1582344681,
     "wof:name":"Kossi",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",

--- a/data/890/413/167/890413167.geojson
+++ b/data/890/413/167/890413167.geojson
@@ -207,6 +207,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb33cb1f29baaa43a53a8e77915328f4",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":890413167,
-    "wof:lastmodified":1566613298,
+    "wof:lastmodified":1582344680,
     "wof:name":"Como\u00e9",
     "wof:parent_id":1108805703,
     "wof:placetype":"county",

--- a/data/890/413/171/890413171.geojson
+++ b/data/890/413/171/890413171.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469050990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"064d64a090bea224e49d3cbe5aac4ddd",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":890413171,
-    "wof:lastmodified":1566613300,
+    "wof:lastmodified":1582344681,
     "wof:name":"K\u00e9n\u00e9dougou",
     "wof:parent_id":1108805687,
     "wof:placetype":"county",

--- a/data/890/416/507/890416507.geojson
+++ b/data/890/416/507/890416507.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051138,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32b213c8116035460b91f1a98588876f",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":890416507,
-    "wof:lastmodified":1566613307,
+    "wof:lastmodified":1582344684,
     "wof:name":"Banwa",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",

--- a/data/890/416/509/890416509.geojson
+++ b/data/890/416/509/890416509.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051138,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c365b54fb838f6fe5cca0f1d37091aa0",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":890416509,
-    "wof:lastmodified":1566613307,
+    "wof:lastmodified":1582344684,
     "wof:name":"Ioba",
     "wof:parent_id":1108805683,
     "wof:placetype":"county",

--- a/data/890/421/457/890421457.geojson
+++ b/data/890/421/457/890421457.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051393,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7d775e4bcc91c918cd32aa05f40d5566",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":890421457,
-    "wof:lastmodified":1566613303,
+    "wof:lastmodified":1582344682,
     "wof:name":"Yatenga",
     "wof:parent_id":1108805701,
     "wof:placetype":"county",

--- a/data/890/421/459/890421459.geojson
+++ b/data/890/421/459/890421459.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051393,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a26724aaf3eaf84c32e2d189c268f10d",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":890421459,
-    "wof:lastmodified":1566613304,
+    "wof:lastmodified":1582344682,
     "wof:name":"Tapoa",
     "wof:parent_id":1108805685,
     "wof:placetype":"county",

--- a/data/890/421/461/890421461.geojson
+++ b/data/890/421/461/890421461.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051393,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41230219e2a79d3c9a9706c2b6c23a28",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":890421461,
-    "wof:lastmodified":1566613303,
+    "wof:lastmodified":1582344682,
     "wof:name":"Sourou",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",

--- a/data/890/421/463/890421463.geojson
+++ b/data/890/421/463/890421463.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051393,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2bce0646c7891822d3df12605b890a2f",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":890421463,
-    "wof:lastmodified":1566613303,
+    "wof:lastmodified":1582344682,
     "wof:name":"Soum",
     "wof:parent_id":1108805689,
     "wof:placetype":"county",

--- a/data/890/421/465/890421465.geojson
+++ b/data/890/421/465/890421465.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051393,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81989739af9d2f36795d769df4ae639f",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":890421465,
-    "wof:lastmodified":1566613303,
+    "wof:lastmodified":1582344682,
     "wof:name":"Sissili",
     "wof:parent_id":1108805695,
     "wof:placetype":"county",

--- a/data/890/421/707/890421707.geojson
+++ b/data/890/421/707/890421707.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051404,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c1919dc043d0168f6ffc5463045e73d",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":890421707,
-    "wof:lastmodified":1566613302,
+    "wof:lastmodified":1582344682,
     "wof:name":"Koulp\u00e9logo",
     "wof:parent_id":1108805705,
     "wof:placetype":"county",

--- a/data/890/422/527/890422527.geojson
+++ b/data/890/422/527/890422527.geojson
@@ -209,6 +209,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051450,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5c475c019770582936ac948aa878602",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
         }
     ],
     "wof:id":890422527,
-    "wof:lastmodified":1566613296,
+    "wof:lastmodified":1582344680,
     "wof:name":"Tuy",
     "wof:parent_id":1108805687,
     "wof:placetype":"county",

--- a/data/890/422/529/890422529.geojson
+++ b/data/890/422/529/890422529.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051450,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"769adb6bcf2200ddf2104022e2364b40",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":890422529,
-    "wof:lastmodified":1566613296,
+    "wof:lastmodified":1582344680,
     "wof:name":"Yagha",
     "wof:parent_id":1108805689,
     "wof:placetype":"county",

--- a/data/890/422/531/890422531.geojson
+++ b/data/890/422/531/890422531.geojson
@@ -201,6 +201,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051450,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e70883bc8a5b4e956fcbb2d9ef8b98c",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":890422531,
-    "wof:lastmodified":1566613296,
+    "wof:lastmodified":1582344680,
     "wof:name":"Ziro",
     "wof:parent_id":1108805695,
     "wof:placetype":"county",

--- a/data/890/422/535/890422535.geojson
+++ b/data/890/422/535/890422535.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051450,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f1d6292bf21e331dc9919d72b64847ce",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":890422535,
-    "wof:lastmodified":1566613296,
+    "wof:lastmodified":1582344680,
     "wof:name":"Zondoma",
     "wof:parent_id":1108805701,
     "wof:placetype":"county",

--- a/data/890/428/969/890428969.geojson
+++ b/data/890/428/969/890428969.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051784,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"31e773b9d43dda855f5d7bfab6c8f5ce",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":890428969,
-    "wof:lastmodified":1566613305,
+    "wof:lastmodified":1582344683,
     "wof:name":"Houet",
     "wof:parent_id":1108805687,
     "wof:placetype":"county",

--- a/data/890/428/971/890428971.geojson
+++ b/data/890/428/971/890428971.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051784,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"caed4ed5cf32fd4872af48482a75ef6d",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":890428971,
-    "wof:lastmodified":1566613305,
+    "wof:lastmodified":1582344683,
     "wof:name":"Gourma",
     "wof:parent_id":1108805685,
     "wof:placetype":"county",

--- a/data/890/428/975/890428975.geojson
+++ b/data/890/428/975/890428975.geojson
@@ -214,6 +214,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051785,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"39e3a5a248dab3895d015f82f47fa07c",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
         }
     ],
     "wof:id":890428975,
-    "wof:lastmodified":1566613306,
+    "wof:lastmodified":1582344683,
     "wof:name":"Gnagna",
     "wof:parent_id":1108805685,
     "wof:placetype":"county",

--- a/data/890/428/979/890428979.geojson
+++ b/data/890/428/979/890428979.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051785,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7888133662675259516c0e0d38368885",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":890428979,
-    "wof:lastmodified":1566613304,
+    "wof:lastmodified":1582344683,
     "wof:name":"Ganzourgou",
     "wof:parent_id":1108805691,
     "wof:placetype":"county",

--- a/data/890/428/981/890428981.geojson
+++ b/data/890/428/981/890428981.geojson
@@ -210,6 +210,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051785,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b389ea4d250b79720021a0b5fba7f4a0",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":890428981,
-    "wof:lastmodified":1566613306,
+    "wof:lastmodified":1582344683,
     "wof:name":"Boulkiemd\u00e9",
     "wof:parent_id":1108805695,
     "wof:placetype":"county",

--- a/data/890/428/983/890428983.geojson
+++ b/data/890/428/983/890428983.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051785,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"083d2c41949139b77d5be3edd55d0980",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":890428983,
-    "wof:lastmodified":1566613304,
+    "wof:lastmodified":1582344683,
     "wof:name":"Boulgou",
     "wof:parent_id":1108805705,
     "wof:placetype":"county",

--- a/data/890/428/985/890428985.geojson
+++ b/data/890/428/985/890428985.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051785,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8475fa71099ace23bab384d06fa43a66",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":890428985,
-    "wof:lastmodified":1566613305,
+    "wof:lastmodified":1582344683,
     "wof:name":"Bougouriba",
     "wof:parent_id":1108805683,
     "wof:placetype":"county",

--- a/data/890/428/989/890428989.geojson
+++ b/data/890/428/989/890428989.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469051785,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c004465e6dd1f0e86affd3353509bec7",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":890428989,
-    "wof:lastmodified":1566613306,
+    "wof:lastmodified":1582344683,
     "wof:name":"Bam",
     "wof:parent_id":1108805709,
     "wof:placetype":"county",

--- a/data/890/435/617/890435617.geojson
+++ b/data/890/435/617/890435617.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469052075,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67a7967d9371843babcfc5eed06ddce4",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":890435617,
-    "wof:lastmodified":1566613308,
+    "wof:lastmodified":1582344684,
     "wof:name":"Komandjoari",
     "wof:parent_id":1108805685,
     "wof:placetype":"county",

--- a/data/890/452/781/890452781.geojson
+++ b/data/890/452/781/890452781.geojson
@@ -210,6 +210,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469052830,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19fda5082c56703db3dfadd73190be95",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":890452781,
-    "wof:lastmodified":1566613301,
+    "wof:lastmodified":1582344682,
     "wof:name":"Bal\u00e9",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",

--- a/data/890/453/941/890453941.geojson
+++ b/data/890/453/941/890453941.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469052879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ac502c566f06ca25b043859dfd1543a",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":890453941,
-    "wof:lastmodified":1566613301,
+    "wof:lastmodified":1582344682,
     "wof:name":"Kompienga",
     "wof:parent_id":1108805685,
     "wof:placetype":"county",

--- a/data/890/453/945/890453945.geojson
+++ b/data/890/453/945/890453945.geojson
@@ -199,6 +199,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469052879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0b6df946cfa78e20c70835c6bc8c917d",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":890453945,
-    "wof:lastmodified":1566613302,
+    "wof:lastmodified":1582344682,
     "wof:name":"Kourw\u00e9ogo",
     "wof:parent_id":1108805691,
     "wof:placetype":"county",

--- a/data/890/453/947/890453947.geojson
+++ b/data/890/453/947/890453947.geojson
@@ -207,6 +207,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469052879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"feccfd8d02f5bc0cb089b6e4f9a6fbda",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":890453947,
-    "wof:lastmodified":1566613302,
+    "wof:lastmodified":1582344682,
     "wof:name":"L\u00e9raba",
     "wof:parent_id":1108805703,
     "wof:placetype":"county",

--- a/data/890/453/949/890453949.geojson
+++ b/data/890/453/949/890453949.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469052879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4af3b47bb7a9a6f43c2d3a3ac0091fb0",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":890453949,
-    "wof:lastmodified":1566613302,
+    "wof:lastmodified":1582344682,
     "wof:name":"Loroum",
     "wof:parent_id":1108805701,
     "wof:placetype":"county",

--- a/data/890/453/951/890453951.geojson
+++ b/data/890/453/951/890453951.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"BF",
     "wof:created":1469052879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"232658f8e1a60accf1d8bbd276e1eb71",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890453951,
-    "wof:lastmodified":1566613302,
+    "wof:lastmodified":1582344682,
     "wof:name":"Nayala",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.