### PR TITLE
Name updates

### DIFF
--- a/data/856/322/13/85632213.geojson
+++ b/data/856/322/13/85632213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":22.681667,
-    "geom:area_square_m":273990722868.512634,
+    "geom:area_square_m":273990722531.619019,
     "geom:bbox":"-5.521112,9.393889,2.404293,15.085111",
     "geom:latitude":12.276301,
     "geom:longitude":-1.74337,
@@ -61,6 +61,9 @@
     "name:arg_x_preferred":[
         "Burkina Faso"
     ],
+    "name:ary_x_preferred":[
+        "\u0628\u0648\u0631\u0643\u064a\u0646\u0627 \u0641\u0627\u0635\u0648"
+    ],
     "name:arz_x_preferred":[
         "\u0628\u0648\u0631\u0643\u064a\u0646\u0627 \u0641\u0627\u0633\u0648"
     ],
@@ -87,6 +90,9 @@
     ],
     "name:bam_x_variant":[
         "Burukina Faso"
+    ],
+    "name:ban_x_preferred":[
+        "Burkina Faso"
     ],
     "name:bar_x_preferred":[
         "Burkina Faso"
@@ -169,6 +175,9 @@
     "name:crh_x_preferred":[
         "Burkina Faso"
     ],
+    "name:csb_x_preferred":[
+        "B\u00f9rkina Faso"
+    ],
     "name:cym_x_preferred":[
         "Bwrcina Ffaso"
     ],
@@ -176,6 +185,12 @@
         "Burkina Faso"
     ],
     "name:dan_x_preferred":[
+        "Burkina Faso"
+    ],
+    "name:deu_at_x_preferred":[
+        "Burkina Faso"
+    ],
+    "name:deu_ch_x_preferred":[
         "Burkina Faso"
     ],
     "name:deu_x_preferred":[
@@ -195,6 +210,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03bf\u03c5\u03c1\u03ba\u03af\u03bd\u03b1 \u03a6\u03ac\u03c3\u03bf"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Burkina Faso"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Burkina Faso"
     ],
     "name:eng_x_preferred":[
         "Burkina Faso"
@@ -261,6 +282,9 @@
     ],
     "name:gag_x_preferred":[
         "Burkina Faso"
+    ],
+    "name:gcr_x_preferred":[
+        "Birkina Faso"
     ],
     "name:gla_x_preferred":[
         "Buirciona Faso"
@@ -618,6 +642,9 @@
     "name:pol_x_preferred":[
         "Burkina Faso"
     ],
+    "name:por_br_x_preferred":[
+        "Burkina Faso"
+    ],
     "name:por_x_preferred":[
         "Burkina Faso"
     ],
@@ -697,6 +724,9 @@
     "name:sna_x_variant":[
         "Bukinafaso"
     ],
+    "name:snd_x_preferred":[
+        "\u0628\u0631\u06aa\u064a\u0646\u0627 \u0641\u0627\u0633\u0648"
+    ],
     "name:som_x_preferred":[
         "Burkina Faso"
     ],
@@ -716,6 +746,12 @@
         "Burkina Faso"
     ],
     "name:srd_x_preferred":[
+        "Burkina Faso"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u0411\u0443\u0440\u043a\u0438\u043d\u0430 \u0424\u0430\u0441\u043e"
+    ],
+    "name:srp_el_x_preferred":[
         "Burkina Faso"
     ],
     "name:srp_x_preferred":[
@@ -741,6 +777,9 @@
     ],
     "name:szl_x_preferred":[
         "Burkina Faso"
+    ],
+    "name:szy_x_preferred":[
+        "Burkina faso"
     ],
     "name:tam_x_preferred":[
         "\u0baa\u0bc1\u0bb0\u0bcd\u0b95\u0bcd\u0b95\u0bbf\u0ba9\u0bbe \u0baa\u0bbe\u0b9a\u0bcb"
@@ -863,8 +902,17 @@
     "name:zha_x_preferred":[
         "Burkina Faso"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5e03\u57fa\u7eb3\u6cd5\u7d22"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5e03\u57fa\u7d0d\u6cd5\u7d22"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Burkina Faso"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5e03\u5409\u7d0d\u6cd5\u7d22"
     ],
     "name:zho_x_preferred":[
         "\u5e03\u5409\u7d0d\u6cd5\u7d22"
@@ -1030,7 +1078,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1583797281,
+    "wof:lastmodified":1587428002,
     "wof:name":"Burkina Faso",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.