### PR TITLE
bf concordances, placetype local, and more

### DIFF
--- a/data/110/869/364/3/1108693643.geojson
+++ b/data/110/869/364/3/1108693643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231333,
-    "geom:area_square_m":2818086631.842005,
+    "geom:area_square_m":2818086487.912705,
     "geom:bbox":"-3.295373,9.40111,-2.68992,10.198949",
     "geom:latitude":9.874354,
     "geom:longitude":-2.959007,
@@ -195,9 +195,10 @@
         "hasc:id":"BF.SO.NB",
         "wd:id":"Q646647"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1474414888,
-    "wof:geomhash":"fcc16e845e47620f0d07de372176d2ed",
+    "wof:geomhash":"e3c881238f74df2ba8bd46bf93cb8bdc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -207,7 +208,7 @@
         }
     ],
     "wof:id":1108693643,
-    "wof:lastmodified":1690856944,
+    "wof:lastmodified":1695886754,
     "wof:name":"Noumbiel",
     "wof:parent_id":1108805683,
     "wof:placetype":"county",

--- a/data/110/869/364/5/1108693645.geojson
+++ b/data/110/869/364/5/1108693645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.303887,
-    "geom:area_square_m":3681233332.884554,
+    "geom:area_square_m":3681232608.452732,
     "geom:bbox":"-1.34575,11.161529,-0.558263,11.951402",
     "geom:latitude":11.571637,
     "geom:longitude":-0.979185,
@@ -199,9 +199,10 @@
         "hasc:id":"BF.CS.ZW",
         "wd:id":"Q227059"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1474414903,
-    "wof:geomhash":"076e7a7f4a3573285a3d2d537ac5e297",
+    "wof:geomhash":"1daf0cbf03ba53a36c66faa32e854830",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1108693645,
-    "wof:lastmodified":1690856944,
+    "wof:lastmodified":1695886849,
     "wof:name":"Zoundw\u00e9ogo",
     "wof:parent_id":1108805699,
     "wof:placetype":"county",

--- a/data/110/869/364/9/1108693649.geojson
+++ b/data/110/869/364/9/1108693649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.327645,
-    "geom:area_square_m":3963424739.599218,
+    "geom:area_square_m":3963425687.496748,
     "geom:bbox":"-2.05144,11.592349,-0.885609,12.204348",
     "geom:latitude":11.96059,
     "geom:longitude":-1.452626,
@@ -199,9 +199,10 @@
         "hasc:id":"BF.CS.BZ",
         "wd:id":"Q619764"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1474414909,
-    "wof:geomhash":"7b5b2d135194d1348875da8ae8e7c967",
+    "wof:geomhash":"99583422a42b7a777a9b2323a612695a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1108693649,
-    "wof:lastmodified":1690856943,
+    "wof:lastmodified":1695886849,
     "wof:name":"Baz\u00e8ga",
     "wof:parent_id":1108805699,
     "wof:placetype":"county",

--- a/data/110/869/365/1/1108693651.geojson
+++ b/data/110/869/365/1/1108693651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.331564,
-    "geom:area_square_m":3996363202.817159,
+    "geom:area_square_m":3996362623.086187,
     "geom:bbox":"-2.734041,12.616235,-1.532085,13.168857",
     "geom:latitude":12.900509,
     "geom:longitude":-2.169157,
@@ -196,9 +196,10 @@
         "hasc:id":"BF.NO.PA",
         "wd:id":"Q1142008"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1474414918,
-    "wof:geomhash":"7aace389bd3db8ecf1d0790019951d8b",
+    "wof:geomhash":"38d4483558028589900e3f1cd2a2f481",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":1108693651,
-    "wof:lastmodified":1690856943,
+    "wof:lastmodified":1695886849,
     "wof:name":"Passor\u00e9",
     "wof:parent_id":1108805701,
     "wof:placetype":"county",

--- a/data/110/880/568/3/1108805683.geojson
+++ b/data/110/880/568/3/1108805683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.349337,
-    "geom:area_square_m":16406082059.517784,
+    "geom:area_square_m":16406081756.895708,
     "geom:bbox":"-3.999979,9.40111,-2.6062,11.368111",
     "geom:latitude":10.478039,
     "geom:longitude":-3.232801,
@@ -167,12 +167,14 @@
     "wof:concordances":{
         "fips:code":"UV91",
         "hasc:id":"BF.SO",
+        "iso:code":"BF-13",
         "iso:id":"BF-13",
         "wd:id":"Q429149"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828362,
-    "wof:geomhash":"a50189874dafb0aaf846656b9431d7af",
+    "wof:geomhash":"6f6edd5011e945b2d467db3387db5f06",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -187,7 +189,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690856941,
+    "wof:lastmodified":1695884869,
     "wof:name":"Sud-Ouest",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/568/5/1108805685.geojson
+++ b/data/110/880/568/5/1108805685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.868322,
-    "geom:area_square_m":46745096422.310333,
+    "geom:area_square_m":46745097051.006371,
     "geom:bbox":"-0.39059,10.931,2.4054,13.578306",
     "geom:latitude":12.227389,
     "geom:longitude":0.919322,
@@ -164,12 +164,14 @@
     "wof:concordances":{
         "fips:code":"UV86",
         "hasc:id":"BF.ES",
+        "iso:code":"BF-08",
         "iso:id":"BF-08",
         "wd:id":"Q850088"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828363,
-    "wof:geomhash":"01713cdc359e81e9234046a1385c418f",
+    "wof:geomhash":"82f23089d205c5aee6d24994079be9da",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -184,7 +186,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690856942,
+    "wof:lastmodified":1695884869,
     "wof:name":"Est",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/568/7/1108805687.geojson
+++ b/data/110/880/568/7/1108805687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.121831,
-    "geom:area_square_m":25721755188.676262,
+    "geom:area_square_m":25721754913.472507,
     "geom:bbox":"-5.49653,10.669846,-2.82997,12.107663",
     "geom:latitude":11.367824,
     "geom:longitude":-4.332121,
@@ -116,11 +116,13 @@
         "gn:id":2360075,
         "gp:id":2347618,
         "hasc:id":"BF.HB",
+        "iso:code":"BF-09",
         "iso:id":"BF-09"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828363,
-    "wof:geomhash":"c7e63b3f5d258b4589b5533bd8328e92",
+    "wof:geomhash":"11a8fd757858ad4e6818366e420a7037",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -135,7 +137,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1614893060,
+    "wof:lastmodified":1695884484,
     "wof:name":"Hauts-Bassins",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/568/9/1108805689.geojson
+++ b/data/110/880/568/9/1108805689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.026825,
-    "geom:area_square_m":36290846382.246941,
+    "geom:area_square_m":36290846060.901268,
     "geom:bbox":"-2.105819,12.969933,1.28297,15.08259",
     "geom:latitude":14.146781,
     "geom:longitude":-0.441062,
@@ -164,12 +164,14 @@
     "wof:concordances":{
         "fips:code":"UV90",
         "hasc:id":"BF.SA",
+        "iso:code":"BF-12",
         "iso:id":"BF-12",
         "wd:id":"Q665514"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828363,
-    "wof:geomhash":"5b0b5f603a19368f3292fc78af0f2ba7",
+    "wof:geomhash":"7e919ff7203f94d3c553795dd9c089e5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -184,7 +186,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690856941,
+    "wof:lastmodified":1695884325,
     "wof:name":"Sahel",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/569/1/1108805691.geojson
+++ b/data/110/880/569/1/1108805691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.715341,
-    "geom:area_square_m":8637254222.198538,
+    "geom:area_square_m":8637254585.392174,
     "geom:bbox":"-2.082986,11.87382,-0.411314,12.933117",
     "geom:latitude":12.449697,
     "geom:longitude":-1.142959,
@@ -167,12 +167,14 @@
     "wof:concordances":{
         "fips:code":"UV89",
         "hasc:id":"BF.PC",
+        "iso:code":"BF-11",
         "iso:id":"BF-11",
         "wd:id":"Q862606"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828364,
-    "wof:geomhash":"23c09fb6cd6f2756b62b0951bbb2062d",
+    "wof:geomhash":"e85783e65e00435037c11e9257b19d29",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -187,7 +189,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690856941,
+    "wof:lastmodified":1695884325,
     "wof:name":"Plateau Central",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/569/3/1108805693.geojson
+++ b/data/110/880/569/3/1108805693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238447,
-    "geom:area_square_m":2880514761.77486,
+    "geom:area_square_m":2880514008.519333,
     "geom:bbox":"-1.826852,12.05131,-1.063634,12.685051",
     "geom:latitude":12.322549,
     "geom:longitude":-1.502275,
@@ -185,12 +185,14 @@
     "wof:concordances":{
         "fips:code":"UV81",
         "hasc:id":"BF.CT",
+        "iso:code":"BF-03",
         "iso:id":"BF-03",
         "wd:id":"Q515655"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828364,
-    "wof:geomhash":"42e713b948a1b57a6def05f8e44fd34c",
+    "wof:geomhash":"9d79c9172d64cb59c98f325849609acc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -205,7 +207,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690856941,
+    "wof:lastmodified":1695884869,
     "wof:name":"Centre",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/569/5/1108805695.geojson
+++ b/data/110/880/569/5/1108805695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.810284,
-    "geom:area_square_m":21911297150.354424,
+    "geom:area_square_m":21911297083.320194,
     "geom:bbox":"-2.928885,10.97613,-1.309292,12.841725",
     "geom:latitude":11.792338,
     "geom:longitude":-2.218591,
@@ -23,7 +23,7 @@
     "lbl:longitude":-2.058052,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":9.0,
     "name:eng_x_preferred":[
@@ -56,11 +56,13 @@
     "wof:concordances":{
         "fips:code":"UV84",
         "hasc:id":"BF.CO",
+        "iso:code":"BF-06",
         "iso:id":"BF-06"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828364,
-    "wof:geomhash":"08106889a8e0ac2e3b3985f31d4ab7d8",
+    "wof:geomhash":"ae43be519f94bcc6428e7093fd341803",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +77,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1614893059,
+    "wof:lastmodified":1695884282,
     "wof:name":"Centre-Ouest",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/569/9/1108805699.geojson
+++ b/data/110/880/569/9/1108805699.geojson
@@ -80,7 +80,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1695880874,
+    "wof:lastmodified":1695884280,
     "wof:name":"Centre-Sud",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/569/9/1108805699.geojson
+++ b/data/110/880/569/9/1108805699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.954191,
-    "geom:area_square_m":11558356252.691715,
+    "geom:area_square_m":11558356252.69173,
     "geom:bbox":"-2.051440047,10.95909,-0.558263024,12.204348229",
     "geom:latitude":11.580856,
     "geom:longitude":-1.218308,
@@ -23,7 +23,7 @@
     "lbl:longitude":-1.083142,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":9.0,
     "name:eng_x_preferred":[
@@ -59,11 +59,13 @@
     "wof:concordances":{
         "fips:code":"UV85",
         "hasc:id":"BF.CS",
+        "iso:code":"BF-07",
         "iso:id":"BF-07"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828365,
-    "wof:geomhash":"a0ee1c1687e35f7260b93fc51835ac3f",
+    "wof:geomhash":"3352328b8759cca379f6a8343ed95934",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +80,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566613144,
+    "wof:lastmodified":1695880874,
     "wof:name":"Centre-Sud",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/570/1/1108805701.geojson
+++ b/data/110/880/570/1/1108805701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.369645,
-    "geom:area_square_m":16470322728.425413,
+    "geom:area_square_m":16470321658.679596,
     "geom:bbox":"-2.953706,12.616235,-1.532085,14.29787",
     "geom:latitude":13.458961,
     "geom:longitude":-2.28311,
@@ -179,12 +179,14 @@
     "wof:concordances":{
         "fips:code":"UV88",
         "hasc:id":"BF.NO",
+        "iso:code":"BF-10",
         "iso:id":"BF-10",
         "wd:id":"Q502320"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828365,
-    "wof:geomhash":"2eb0888caa8e4cd21f8a6bd16d8b0769",
+    "wof:geomhash":"f7411b5fc3570b242a098898b5c6ae44",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -199,7 +201,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690856942,
+    "wof:lastmodified":1695884869,
     "wof:name":"Nord",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/570/3/1108805703.geojson
+++ b/data/110/880/570/3/1108805703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.533288,
-    "geom:area_square_m":18650539180.555618,
+    "geom:area_square_m":18650539802.006046,
     "geom:bbox":"-5.51892,9.59407,-3.673099,11.022831",
     "geom:latitude":10.351714,
     "geom:longitude":-4.570418,
@@ -167,12 +167,14 @@
     "wof:concordances":{
         "fips:code":"UV80",
         "hasc:id":"BF.CD",
+        "iso:code":"BF-02",
         "iso:id":"BF-02",
         "wd:id":"Q850043"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828366,
-    "wof:geomhash":"2de92318329a949ab327a642c8a37005",
+    "wof:geomhash":"f2d716164f31bd61b472f8e73a6ec101",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -187,7 +189,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690856943,
+    "wof:lastmodified":1695884326,
     "wof:name":"Cascades",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/570/5/1108805705.geojson
+++ b/data/110/880/570/5/1108805705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.218348,
-    "geom:area_square_m":14756823871.54323,
+    "geom:area_square_m":14756823941.363487,
     "geom:bbox":"-0.902262,10.90218,0.588261,12.560673",
     "geom:latitude":11.605337,
     "geom:longitude":-0.186054,
@@ -23,7 +23,7 @@
     "lbl:longitude":-0.197271,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":9.0,
     "name:eng_x_preferred":[
@@ -56,11 +56,13 @@
     "wof:concordances":{
         "fips:code":"UV82",
         "hasc:id":"BF.CE",
+        "iso:code":"BF-04",
         "iso:id":"BF-04"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828366,
-    "wof:geomhash":"d877652d412c5b8c14c794e7a1710741",
+    "wof:geomhash":"257c79464a44de49fb7b2afc72e95c3d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +77,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1614893060,
+    "wof:lastmodified":1695884282,
     "wof:name":"Centre-Est",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/570/7/1108805707.geojson
+++ b/data/110/880/570/7/1108805707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.87344,
-    "geom:area_square_m":34681423692.136826,
+    "geom:area_square_m":34681423979.36348,
     "geom:bbox":"-4.650182,11.239415,-2.441404,13.71847",
     "geom:latitude":12.540666,
     "geom:longitude":-3.488817,
@@ -167,12 +167,14 @@
     "wof:concordances":{
         "fips:code":"UV79",
         "hasc:id":"BF.BO",
+        "iso:code":"BF-01",
         "iso:id":"BF-01",
         "wd:id":"Q527093"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828366,
-    "wof:geomhash":"f8fd0f8d526112fc647bcef88a21c13d",
+    "wof:geomhash":"ad739a172e38feba0806a083b4d57f7e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -187,7 +189,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690856942,
+    "wof:lastmodified":1695884325,
     "wof:name":"Boucle du Mouhoun",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/110/880/570/9/1108805709.geojson
+++ b/data/110/880/570/9/1108805709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.64067,
-    "geom:area_square_m":19745256752.733875,
+    "geom:area_square_m":19745256952.441429,
     "geom:bbox":"-1.905155,12.479384,-0.213015,13.998738",
     "geom:latitude":13.268769,
     "geom:longitude":-0.97455,
@@ -23,7 +23,7 @@
     "lbl:longitude":-0.974652,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":9.0,
     "name:eng_x_preferred":[
@@ -56,11 +56,13 @@
     "wof:concordances":{
         "fips:code":"UV83",
         "hasc:id":"BF.CN",
+        "iso:code":"BF-05",
         "iso:id":"BF-05"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:created":1485828367,
-    "wof:geomhash":"0930595ad3ac7ce2ca8c634c8c4e92c6",
+    "wof:geomhash":"9b4b9a4c0ce63186b946eaffd8f98cfa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +77,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1614893060,
+    "wof:lastmodified":1695884282,
     "wof:name":"Centre-Nord",
     "wof:parent_id":85632213,
     "wof:placetype":"region",

--- a/data/421/187/907/421187907.geojson
+++ b/data/421/187/907/421187907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238447,
-    "geom:area_square_m":2880514761.77486,
+    "geom:area_square_m":2880514008.519333,
     "geom:bbox":"-1.826852,12.05131,-1.063634,12.685051",
     "geom:latitude":12.322549,
     "geom:longitude":-1.502275,
@@ -242,12 +242,13 @@
         "wd:id":"Q1074530",
         "wk:page":"Kadiogo Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1459009527,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"42e713b948a1b57a6def05f8e44fd34c",
+    "wof:geomhash":"9d79c9172d64cb59c98f325849609acc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -257,7 +258,7 @@
         }
     ],
     "wof:id":421187907,
-    "wof:lastmodified":1690856948,
+    "wof:lastmodified":1695886754,
     "wof:name":"Kadiogo",
     "wof:parent_id":1108805693,
     "wof:placetype":"county",

--- a/data/856/322/13/85632213.geojson
+++ b/data/856/322/13/85632213.geojson
@@ -1194,6 +1194,7 @@
         "hasc:id":"BF",
         "icao:code":"XT",
         "ioc:id":"BUR",
+        "iso:code":"BF",
         "itu:id":"BFA",
         "m49:code":"854",
         "marc:id":"uv",
@@ -1207,6 +1208,7 @@
         "wk:page":"Burkina Faso",
         "wmo:id":"HV"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BF",
     "wof:country_alpha3":"BFA",
     "wof:geom_alt":[
@@ -1228,7 +1230,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639578,
+    "wof:lastmodified":1695881238,
     "wof:name":"Burkina Faso",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/890/413/143/890413143.geojson
+++ b/data/890/413/143/890413143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.532364,
-    "geom:area_square_m":6409218476.20006,
+    "geom:area_square_m":6409217678.832076,
     "geom:bbox":"-0.816604,12.479384,-0.213015,13.998738",
     "geom:latitude":13.18068,
     "geom:longitude":-0.508672,
@@ -219,12 +219,13 @@
         "qs_pg:id":573777,
         "wd:id":"Q1142044"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050989,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05c172a771d2b563e6a99aba0b206cd1",
+    "wof:geomhash":"f3d7b752ccae91826f32ab213300d0f6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -234,7 +235,7 @@
         }
     ],
     "wof:id":890413143,
-    "wof:lastmodified":1690856956,
+    "wof:lastmodified":1695886755,
     "wof:name":"Namentenga",
     "wof:parent_id":1108805709,
     "wof:placetype":"county",

--- a/data/890/413/145/890413145.geojson
+++ b/data/890/413/145/890413145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.585411,
-    "geom:area_square_m":7025257409.400127,
+    "geom:area_square_m":7025257857.562669,
     "geom:bbox":"-0.63455,13.508465,0.527407,14.428569",
     "geom:latitude":13.947772,
     "geom:longitude":-0.032402,
@@ -205,12 +205,13 @@
         "qs_pg:id":573769,
         "wd:id":"Q1061214"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7f4ba27e7b4837f448cb505883c12940",
+    "wof:geomhash":"5ef015b057058f4729239c36eb97d587",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -220,7 +221,7 @@
         }
     ],
     "wof:id":890413145,
-    "wof:lastmodified":1690856956,
+    "wof:lastmodified":1695886781,
     "wof:name":"S\u00e9no",
     "wof:parent_id":1108805689,
     "wof:placetype":"county",

--- a/data/890/413/147/890413147.geojson
+++ b/data/890/413/147/890413147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.773473,
-    "geom:area_square_m":9309676508.887709,
+    "geom:area_square_m":9309677064.092621,
     "geom:bbox":"-1.551245,12.542872,-0.656373,13.948937",
     "geom:latitude":13.242164,
     "geom:longitude":-1.030404,
@@ -219,12 +219,13 @@
         "qs_pg:id":573770,
         "wd:id":"Q1142039"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"88d3f5c33ef149a1e307f2c0d36cbb7e",
+    "wof:geomhash":"0c64b4ba13a814ddc8fe7f1ebdb11347",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -234,7 +235,7 @@
         }
     ],
     "wof:id":890413147,
-    "wof:lastmodified":1690856957,
+    "wof:lastmodified":1695886755,
     "wof:name":"Sanmatenga",
     "wof:parent_id":1108805709,
     "wof:placetype":"county",

--- a/data/890/413/149/890413149.geojson
+++ b/data/890/413/149/890413149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.424608,
-    "geom:area_square_m":5131478412.108816,
+    "geom:area_square_m":5131478319.084503,
     "geom:bbox":"-2.928885,11.605415,-2.229895,12.841725",
     "geom:latitude":12.212219,
     "geom:longitude":-2.613819,
@@ -205,12 +205,13 @@
         "qs_pg:id":573771,
         "wd:id":"Q1142014"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b9a7a07cd72c1f8de8b7a153d4b056fc",
+    "wof:geomhash":"75a5f35d29d1c0386e9c6d32292b84d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -220,7 +221,7 @@
         }
     ],
     "wof:id":890413149,
-    "wof:lastmodified":1690856957,
+    "wof:lastmodified":1695886781,
     "wof:name":"Sangui\u00e9",
     "wof:parent_id":1108805695,
     "wof:placetype":"county",

--- a/data/890/413/151/890413151.geojson
+++ b/data/890/413/151/890413151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.618131,
-    "geom:area_square_m":7520044347.260622,
+    "geom:area_square_m":7520044114.776317,
     "geom:bbox":"-3.999979,9.85163,-2.76253,10.769703",
     "geom:latitude":10.302049,
     "geom:longitude":-3.360044,
@@ -210,12 +210,13 @@
         "qs_pg:id":573772,
         "wd:id":"Q953657"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e896e6c3f031f96ddad02767fdb12924",
+    "wof:geomhash":"063c72a2b6d87657d2912f55bb2420c9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":890413151,
-    "wof:lastmodified":1690856955,
+    "wof:lastmodified":1695886755,
     "wof:name":"Poni",
     "wof:parent_id":1108805683,
     "wof:placetype":"county",

--- a/data/890/413/153/890413153.geojson
+++ b/data/890/413/153/890413153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.839772,
-    "geom:area_square_m":10046111248.461306,
+    "geom:area_square_m":10046110834.013628,
     "geom:bbox":"-1.046731,14.162663,0.2361,15.08259",
     "geom:latitude":14.653276,
     "geom:longitude":-0.333657,
@@ -213,12 +213,13 @@
         "qs_pg:id":573774,
         "wd:id":"Q514173"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2108cfe3e4f296626dc0956dc55eff8b",
+    "wof:geomhash":"9e625d8a7aab3eeef75f95e560d23c9c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":890413153,
-    "wof:lastmodified":1690856956,
+    "wof:lastmodified":1695886755,
     "wof:name":"Oudalan",
     "wof:parent_id":1108805689,
     "wof:placetype":"county",

--- a/data/890/413/157/890413157.geojson
+++ b/data/890/413/157/890413157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.2364,
-    "geom:area_square_m":2852286070.581028,
+    "geom:area_square_m":2852286699.409568,
     "geom:bbox":"-1.724189,12.260422,-0.853479,12.933117",
     "geom:latitude":12.63935,
     "geom:longitude":-1.307179,
@@ -216,12 +216,13 @@
         "qs_pg:id":573775,
         "wd:id":"Q1142026"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"084aa6955015144edc7ca530073b4c9c",
+    "wof:geomhash":"85f4b102411c75659ace165cc78995d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":890413157,
-    "wof:lastmodified":1690856954,
+    "wof:lastmodified":1695886754,
     "wof:name":"Oubritenga",
     "wof:parent_id":1108805691,
     "wof:placetype":"county",

--- a/data/890/413/159/890413159.geojson
+++ b/data/890/413/159/890413159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.322659,
-    "geom:area_square_m":3913698180.207964,
+    "geom:area_square_m":3913698381.38111,
     "geom:bbox":"-1.662714,10.95909,-0.679071,11.546898",
     "geom:latitude":11.203937,
     "geom:longitude":-1.205582,
@@ -219,12 +219,13 @@
         "wd:id":"Q1142003",
         "wk:page":"Nahouri Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa772da541be0a95b2d1261cb6f8354e",
+    "wof:geomhash":"e2cd1d2949577e3180e3a0d5d750b465",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -234,7 +235,7 @@
         }
     ],
     "wof:id":890413159,
-    "wof:lastmodified":1636500513,
+    "wof:lastmodified":1695886754,
     "wof:name":"Nahouri",
     "wof:parent_id":1108805699,
     "wof:placetype":"county",

--- a/data/890/413/161/890413161.geojson
+++ b/data/890/413/161/890413161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.571324,
-    "geom:area_square_m":6904914867.114743,
+    "geom:area_square_m":6904914277.892813,
     "geom:bbox":"-3.981598,11.725408,-2.790584,12.749195",
     "geom:latitude":12.200777,
     "geom:longitude":-3.416955,
@@ -207,12 +207,13 @@
         "qs_pg:id":573778,
         "wd:id":"Q1142050"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b85ae0dd30e9af8d7896b5701e3b19c",
+    "wof:geomhash":"088a3ad8ce49e70074d046939fa80918",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -222,7 +223,7 @@
         }
     ],
     "wof:id":890413161,
-    "wof:lastmodified":1690856955,
+    "wof:lastmodified":1695886755,
     "wof:name":"Mouhoun",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",

--- a/data/890/413/163/890413163.geojson
+++ b/data/890/413/163/890413163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.232169,
-    "geom:area_square_m":2806034244.447173,
+    "geom:area_square_m":2806033522.143093,
     "geom:bbox":"-0.63282,11.801697,-0.004122,12.560673",
     "geom:latitude":12.1932,
     "geom:longitude":-0.315674,
@@ -224,12 +224,13 @@
         "wd:id":"Q1141767",
         "wk:page":"Kouritenga Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e92f221e50ebff85d20412afcc91acb8",
+    "wof:geomhash":"00b0b100c1777a1e6855eaeae38ef6f9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -239,7 +240,7 @@
         }
     ],
     "wof:id":890413163,
-    "wof:lastmodified":1690856957,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kouritenga",
     "wof:parent_id":1108805705,
     "wof:placetype":"county",

--- a/data/890/413/165/890413165.geojson
+++ b/data/890/413/165/890413165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.622852,
-    "geom:area_square_m":7506513015.894258,
+    "geom:area_square_m":7506513714.29899,
     "geom:bbox":"-4.35698,12.368233,-3.409825,13.5012",
     "geom:latitude":12.924162,
     "geom:longitude":-3.880822,
@@ -219,12 +219,13 @@
         "qs_pg:id":573780,
         "wd:id":"Q1074485"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dfe54423715c2d4b4cf030cdcdc75838",
+    "wof:geomhash":"9101f2bd34652641d7d1cafd11ee501e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -234,7 +235,7 @@
         }
     ],
     "wof:id":890413165,
-    "wof:lastmodified":1690856957,
+    "wof:lastmodified":1695886755,
     "wof:name":"Kossi",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",

--- a/data/890/413/167/890413167.geojson
+++ b/data/890/413/167/890413167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.276191,
-    "geom:area_square_m":15525928367.458298,
+    "geom:area_square_m":15525928840.63653,
     "geom:bbox":"-5.153596,9.59407,-3.673099,10.891671",
     "geom:latitude":10.298198,
     "geom:longitude":-4.430125,
@@ -211,12 +211,13 @@
         "qs_pg:id":573781,
         "wd:id":"Q1074496"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2acbfa4a7a50cb15f4c5b188f3cd401a",
+    "wof:geomhash":"289f1550b4e02381b1ef8894a955a70b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -226,7 +227,7 @@
         }
     ],
     "wof:id":890413167,
-    "wof:lastmodified":1690856955,
+    "wof:lastmodified":1695886781,
     "wof:name":"Como\u00e9",
     "wof:parent_id":1108805703,
     "wof:placetype":"county",

--- a/data/890/413/171/890413171.geojson
+++ b/data/890/413/171/890413171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.699687,
-    "geom:area_square_m":8480214112.243434,
+    "geom:area_square_m":8480214329.959858,
     "geom:bbox":"-5.49653,10.789039,-4.54981,12.038165",
     "geom:latitude":11.424028,
     "geom:longitude":-4.978682,
@@ -211,12 +211,13 @@
         "qs_pg:id":573783,
         "wd:id":"Q1150901"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469050990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e389cfce54b204aae3b8691d18e430b",
+    "wof:geomhash":"4bfb25f0bac63bab2c85de7a03c119fc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -226,7 +227,7 @@
         }
     ],
     "wof:id":890413171,
-    "wof:lastmodified":1690856958,
+    "wof:lastmodified":1695886782,
     "wof:name":"K\u00e9n\u00e9dougou",
     "wof:parent_id":1108805687,
     "wof:placetype":"county",

--- a/data/890/416/507/890416507.geojson
+++ b/data/890/416/507/890416507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.490584,
-    "geom:area_square_m":5927909177.843604,
+    "geom:area_square_m":5927908651.470432,
     "geom:bbox":"-4.650182,11.709267,-3.555573,12.73142",
     "geom:latitude":12.254022,
     "geom:longitude":-4.1711,
@@ -213,12 +213,13 @@
         "qs_pg:id":575149,
         "wd:id":"Q674664"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051138,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"13eaca16bae26ba33ae3726e854569bb",
+    "wof:geomhash":"d3f1b3b40ee97bf7051ee284177cb8e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":890416507,
-    "wof:lastmodified":1690856965,
+    "wof:lastmodified":1695886757,
     "wof:name":"Banwa",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",

--- a/data/890/416/509/890416509.geojson
+++ b/data/890/416/509/890416509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.270295,
-    "geom:area_square_m":3279896081.154819,
+    "geom:area_square_m":3279895952.718756,
     "geom:bbox":"-3.445499,10.705752,-2.6062,11.368111",
     "geom:latitude":11.083741,
     "geom:longitude":-3.023423,
@@ -210,12 +210,13 @@
         "qs_pg:id":575150,
         "wd:id":"Q1074154"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051138,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"691af55b4efe9bf142fe25978361b3dc",
+    "wof:geomhash":"a45d1800b179d20e31f260ce11388462",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":890416509,
-    "wof:lastmodified":1690856965,
+    "wof:lastmodified":1695886757,
     "wof:name":"Ioba",
     "wof:parent_id":1108805683,
     "wof:placetype":"county",

--- a/data/890/421/457/890421457.geojson
+++ b/data/890/421/457/890421457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.564985,
-    "geom:area_square_m":6790094440.923692,
+    "geom:area_square_m":6790094627.86487,
     "geom:bbox":"-2.953706,13.018121,-1.73015,14.143128",
     "geom:latitude":13.603174,
     "geom:longitude":-2.384828,
@@ -216,12 +216,13 @@
         "qs_pg:id":91332,
         "wd:id":"Q1074521"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051393,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a8cd038252ea6939f881d851e4087c42",
+    "wof:geomhash":"392607020c149de6306304fec2dcc7b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":890421457,
-    "wof:lastmodified":1690856961,
+    "wof:lastmodified":1695886756,
     "wof:name":"Yatenga",
     "wof:parent_id":1108805701,
     "wof:placetype":"county",

--- a/data/890/421/459/890421459.geojson
+++ b/data/890/421/459/890421459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.229156,
-    "geom:area_square_m":14862360802.606567,
+    "geom:area_square_m":14862360837.989956,
     "geom:bbox":"1.169545,11.3904,2.4054,12.839377",
     "geom:latitude":12.069054,
     "geom:longitude":1.740144,
@@ -222,12 +222,13 @@
         "qs_pg:id":91333,
         "wd:id":"Q621983"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051393,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5fe04e3f58c6441c86975d04f4630608",
+    "wof:geomhash":"4c716c176993589ffe890332f1375dbc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -237,7 +238,7 @@
         }
     ],
     "wof:id":890421459,
-    "wof:lastmodified":1690856961,
+    "wof:lastmodified":1695886756,
     "wof:name":"Tapoa",
     "wof:parent_id":1108805685,
     "wof:placetype":"county",

--- a/data/890/421/461/890421461.geojson
+++ b/data/890/421/461/890421461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.502275,
-    "geom:area_square_m":6045366158.115169,
+    "geom:area_square_m":6045367088.920134,
     "geom:bbox":"-3.482686,12.784804,-2.441404,13.71847",
     "geom:latitude":13.249453,
     "geom:longitude":-3.01601,
@@ -216,12 +216,13 @@
         "qs_pg:id":91334,
         "wd:id":"Q558703"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051393,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5c240e51d4c71193329983e73506f4ba",
+    "wof:geomhash":"9f54c7fdcca14599fb6c34bd5ccb7aa1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":890421461,
-    "wof:lastmodified":1690856961,
+    "wof:lastmodified":1695886756,
     "wof:name":"Sourou",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",

--- a/data/890/421/463/890421463.geojson
+++ b/data/890/421/463/890421463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.057471,
-    "geom:area_square_m":12674044847.526859,
+    "geom:area_square_m":12674044726.134993,
     "geom:bbox":"-2.105819,13.749068,-0.550645,14.823805",
     "geom:latitude":14.236819,
     "geom:longitude":-1.288694,
@@ -171,12 +171,13 @@
         "qs_pg:id":91335,
         "wd:id":"Q385973"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051393,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4998ac0d5c4a605ffe4a5ae2773d3ab3",
+    "wof:geomhash":"9aca9425ebf94dbd5cfc4f70f0b9f23d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":890421463,
-    "wof:lastmodified":1690856960,
+    "wof:lastmodified":1695886756,
     "wof:name":"Soum",
     "wof:parent_id":1108805689,
     "wof:placetype":"county",

--- a/data/890/421/465/890421465.geojson
+++ b/data/890/421/465/890421465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.591367,
-    "geom:area_square_m":7170724713.548841,
+    "geom:area_square_m":7170725516.520228,
     "geom:bbox":"-2.807468,10.97613,-1.417529,11.924858",
     "geom:latitude":11.293284,
     "geom:longitude":-2.223133,
@@ -213,12 +213,13 @@
         "qs_pg:id":91336,
         "wd:id":"Q964281"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051393,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"71a68718b5ebb61abfb462339cf30e15",
+    "wof:geomhash":"b1f23e6918f0b7678ea7aa7e12c8544a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":890421465,
-    "wof:lastmodified":1690856960,
+    "wof:lastmodified":1695886756,
     "wof:name":"Sissili",
     "wof:parent_id":1108805695,
     "wof:placetype":"county",

--- a/data/890/421/707/890421707.geojson
+++ b/data/890/421/707/890421707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.445273,
-    "geom:area_square_m":5396949075.017827,
+    "geom:area_square_m":5396948896.200419,
     "geom:bbox":"-0.211311,11.024382,0.588261,11.806052",
     "geom:latitude":11.414867,
     "geom:longitude":0.201646,
@@ -208,12 +208,13 @@
         "qs_pg:id":575153,
         "wd:id":"Q934923"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051404,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5187d45079954dded3627cb31d10cc22",
+    "wof:geomhash":"3e84145db8a3c5859ca65c000db2d35e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -223,7 +224,7 @@
         }
     ],
     "wof:id":890421707,
-    "wof:lastmodified":1690856960,
+    "wof:lastmodified":1695886782,
     "wof:name":"Koulp\u00e9logo",
     "wof:parent_id":1108805705,
     "wof:placetype":"county",

--- a/data/890/422/527/890422527.geojson
+++ b/data/890/422/527/890422527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.466074,
-    "geom:area_square_m":5648583481.534076,
+    "geom:area_square_m":5648583410.18421,
     "geom:bbox":"-3.978995,10.987479,-2.82997,11.873216",
     "geom:latitude":11.439538,
     "geom:longitude":-3.518758,
@@ -219,12 +219,13 @@
         "qs_pg:id":575159,
         "wd:id":"Q627844"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051450,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"610ab3a02ff85979f66dbe994eab9ddc",
+    "wof:geomhash":"892ef5a9bc74bc360e1affc8aaf0fb36",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -234,7 +235,7 @@
         }
     ],
     "wof:id":890422527,
-    "wof:lastmodified":1690856953,
+    "wof:lastmodified":1695886755,
     "wof:name":"Tuy",
     "wof:parent_id":1108805687,
     "wof:placetype":"county",

--- a/data/890/422/529/890422529.geojson
+++ b/data/890/422/529/890422529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.54417,
-    "geom:area_square_m":6545432876.858673,
+    "geom:area_square_m":6545432643.189963,
     "geom:bbox":"0.057432,12.969933,1.28297,13.846103",
     "geom:latitude":13.404276,
     "geom:longitude":0.600737,
@@ -210,12 +210,13 @@
         "qs_pg:id":575160,
         "wd:id":"Q1074466"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051450,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4d38cf94ae52e2f9f8ee54426fdb0f81",
+    "wof:geomhash":"02d5b37894e244a9a92b43fbb7ec77ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":890422529,
-    "wof:lastmodified":1690856954,
+    "wof:lastmodified":1695886755,
     "wof:name":"Yagha",
     "wof:parent_id":1108805689,
     "wof:placetype":"county",

--- a/data/890/422/531/890422531.geojson
+++ b/data/890/422/531/890422531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.43884,
-    "geom:area_square_m":5314834881.256128,
+    "geom:area_square_m":5314834572.94353,
     "geom:bbox":"-2.364721,11.283271,-1.309292,11.996132",
     "geom:latitude":11.634596,
     "geom:longitude":-1.889043,
@@ -213,12 +213,13 @@
         "qs_pg:id":575161,
         "wd:id":"Q206019"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051450,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fccb5214413969660f3d62fb3af1255e",
+    "wof:geomhash":"e056eb0b416c91e1c0290e404a0d63b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":890422531,
-    "wof:lastmodified":1690856954,
+    "wof:lastmodified":1695886755,
     "wof:name":"Ziro",
     "wof:parent_id":1108805695,
     "wof:placetype":"county",

--- a/data/890/422/535/890422535.geojson
+++ b/data/890/422/535/890422535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165259,
-    "geom:area_square_m":1989510541.46265,
+    "geom:area_square_m":1989510507.408835,
     "geom:bbox":"-2.715894,12.965793,-2.071794,13.43732",
     "geom:latitude":13.19523,
     "geom:longitude":-2.37578,
@@ -207,12 +207,13 @@
         "qs_pg:id":575162,
         "wd:id":"Q219859"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051450,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"312c34559a83530c0c852f108dd1dd61",
+    "wof:geomhash":"5ee979949a00696381d9c47409f712d3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -222,7 +223,7 @@
         }
     ],
     "wof:id":890422535,
-    "wof:lastmodified":1690856953,
+    "wof:lastmodified":1695886754,
     "wof:name":"Zondoma",
     "wof:parent_id":1108805701,
     "wof:placetype":"county",

--- a/data/890/428/969/890428969.geojson
+++ b/data/890/428/969/890428969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.956071,
-    "geom:area_square_m":11592957594.898422,
+    "geom:area_square_m":11592957173.328403,
     "geom:bbox":"-4.805011,10.669846,-3.600633,12.107663",
     "geom:latitude":11.291733,
     "geom:longitude":-4.255449,
@@ -222,12 +222,13 @@
         "qs_pg:id":91337,
         "wd:id":"Q1074161"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051784,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"739d3b9d4d5b65c7a7582909bb0862a9",
+    "wof:geomhash":"b059a6935246a3b00ecfee0d2f13a0e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -237,7 +238,7 @@
         }
     ],
     "wof:id":890428969,
-    "wof:lastmodified":1690856963,
+    "wof:lastmodified":1695886756,
     "wof:name":"Houet",
     "wof:parent_id":1108805687,
     "wof:placetype":"county",

--- a/data/890/428/971/890428971.geojson
+++ b/data/890/428/971/890428971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.928304,
-    "geom:area_square_m":11221726048.319536,
+    "geom:area_square_m":11221724177.643476,
     "geom:bbox":"-0.146165,11.676546,1.332017,12.780272",
     "geom:latitude":12.14317,
     "geom:longitude":0.629001,
@@ -213,12 +213,13 @@
         "qs_pg:id":91338,
         "wd:id":"Q432317"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051784,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"73935725b74652038794cf38e2be6291",
+    "wof:geomhash":"640e6187b8b8841707ea46dfec6e8fca",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":890428971,
-    "wof:lastmodified":1690856962,
+    "wof:lastmodified":1695886757,
     "wof:name":"Gourma",
     "wof:parent_id":1108805685,
     "wof:placetype":"county",

--- a/data/890/428/975/890428975.geojson
+++ b/data/890/428/975/890428975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.710453,
-    "geom:area_square_m":8561529791.10699,
+    "geom:area_square_m":8561531268.843565,
     "geom:bbox":"-0.39059,12.252808,0.59422,13.578306",
     "geom:latitude":12.943996,
     "geom:longitude":0.019497,
@@ -224,12 +224,13 @@
         "wd:id":"Q1074144",
         "wk:page":"Gnagna Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051785,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0fcbbe32b4c582fbf56cbc4baab01ed0",
+    "wof:geomhash":"064de453592b660194c90602de30a676",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -239,7 +240,7 @@
         }
     ],
     "wof:id":890428975,
-    "wof:lastmodified":1690856964,
+    "wof:lastmodified":1695886757,
     "wof:name":"Gnagna",
     "wof:parent_id":1108805685,
     "wof:placetype":"county",

--- a/data/890/428/979/890428979.geojson
+++ b/data/890/428/979/890428979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.346141,
-    "geom:area_square_m":4182588175.066493,
+    "geom:area_square_m":4182587858.564977,
     "geom:bbox":"-1.1137,11.87382,-0.411314,12.705517",
     "geom:latitude":12.252637,
     "geom:longitude":-0.773846,
@@ -210,12 +210,13 @@
         "qs_pg:id":91341,
         "wd:id":"Q182889"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051785,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"534b61bf5b0069fcdd100902e33dd075",
+    "wof:geomhash":"0f0d8418fcc9c6ca3bd9e6636c38e42a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":890428979,
-    "wof:lastmodified":1690856962,
+    "wof:lastmodified":1695886757,
     "wof:name":"Ganzourgou",
     "wof:parent_id":1108805691,
     "wof:placetype":"county",

--- a/data/890/428/981/890428981.geojson
+++ b/data/890/428/981/890428981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.355468,
-    "geom:area_square_m":4294259143.440666,
+    "geom:area_square_m":4294258674.772001,
     "geom:bbox":"-2.499938,11.923458,-1.785013,12.708338",
     "geom:latitude":12.315766,
     "geom:longitude":-2.145777,
@@ -211,12 +211,13 @@
         "qs_pg:id":91343,
         "wd:id":"Q895102"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051785,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5e2ede9ebe6816ed9ef5a676f3802ecd",
+    "wof:geomhash":"b66021438ac02e61e659dd65e6ae31de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -226,7 +227,7 @@
         }
     ],
     "wof:id":890428981,
-    "wof:lastmodified":1690856964,
+    "wof:lastmodified":1695886782,
     "wof:name":"Boulkiemd\u00e9",
     "wof:parent_id":1108805695,
     "wof:placetype":"county",

--- a/data/890/428/983/890428983.geojson
+++ b/data/890/428/983/890428983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.540906,
-    "geom:area_square_m":6553840552.078162,
+    "geom:area_square_m":6553841523.019952,
     "geom:bbox":"-0.902262,10.90218,0.016088,12.019034",
     "geom:latitude":11.509807,
     "geom:longitude":-0.449571,
@@ -216,12 +216,13 @@
         "qs_pg:id":91344,
         "wd:id":"Q895097"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051785,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1857f285307734951fc2b7e7c8eea9c",
+    "wof:geomhash":"02346389aeee3eadda10b251d94ce04c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":890428983,
-    "wof:lastmodified":1690856962,
+    "wof:lastmodified":1695886757,
     "wof:name":"Boulgou",
     "wof:parent_id":1108805705,
     "wof:placetype":"county",

--- a/data/890/428/985/890428985.geojson
+++ b/data/890/428/985/890428985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.229578,
-    "geom:area_square_m":2788054999.260264,
+    "geom:area_square_m":2788055201.488022,
     "geom:bbox":"-3.791762,10.611368,-3.037325,11.164998",
     "geom:latitude":10.847061,
     "geom:longitude":-3.412604,
@@ -213,12 +213,13 @@
         "qs_pg:id":91345,
         "wd:id":"Q676641"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051785,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"36df6c93a8d048c2d5dffa389dfbf831",
+    "wof:geomhash":"51e19fb0015da033292d1c6183bbd842",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":890428985,
-    "wof:lastmodified":1690856963,
+    "wof:lastmodified":1695886757,
     "wof:name":"Bougouriba",
     "wof:parent_id":1108805683,
     "wof:placetype":"county",

--- a/data/890/428/989/890428989.geojson
+++ b/data/890/428/989/890428989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.334834,
-    "geom:area_square_m":4026361767.646137,
+    "geom:area_square_m":4026362209.516726,
     "geom:bbox":"-1.905155,12.988581,-1.29708,13.891694",
     "geom:latitude":13.470283,
     "geom:longitude":-1.586241,
@@ -213,12 +213,13 @@
         "qs_pg:id":91347,
         "wd:id":"Q620710"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469051785,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"870bac83cb7b6f1556db411676c92dcc",
+    "wof:geomhash":"2ad77fdf266382f47ac88fad7c077719",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -228,7 +229,7 @@
         }
     ],
     "wof:id":890428989,
-    "wof:lastmodified":1690856963,
+    "wof:lastmodified":1695886757,
     "wof:name":"Bam",
     "wof:parent_id":1108805709,
     "wof:placetype":"county",

--- a/data/890/435/617/890435617.geojson
+++ b/data/890/435/617/890435617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.425024,
-    "geom:area_square_m":5125934608.964753,
+    "geom:area_square_m":5125935837.574404,
     "geom:bbox":"0.221626,12.319736,1.317996,13.085434",
     "geom:latitude":12.74826,
     "geom:longitude":0.730307,
@@ -208,12 +208,13 @@
         "qs_pg:id":575151,
         "wd:id":"Q1074479"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469052075,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dc9ec813b90bffcf84c5a0c230495403",
+    "wof:geomhash":"6aa0b98cf926f0eeb7695aa1c2096220",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -223,7 +224,7 @@
         }
     ],
     "wof:id":890435617,
-    "wof:lastmodified":1690856965,
+    "wof:lastmodified":1695886782,
     "wof:name":"Komandjoari",
     "wof:parent_id":1108805685,
     "wof:placetype":"county",

--- a/data/890/452/781/890452781.geojson
+++ b/data/890/452/781/890452781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.376722,
-    "geom:area_square_m":4561061503.51191,
+    "geom:area_square_m":4561061486.386271,
     "geom:bbox":"-3.60167,11.239415,-2.516194,12.107048",
     "geom:latitude":11.722246,
     "geom:longitude":-3.073397,
@@ -211,12 +211,13 @@
         "qs_pg:id":575148,
         "wd:id":"Q805913"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469052830,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"80a4c40ca2949aa5523d3f095f879804",
+    "wof:geomhash":"1899d6fcc8a65ae1748b5975ae807793",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -226,7 +227,7 @@
         }
     ],
     "wof:id":890452781,
-    "wof:lastmodified":1690856958,
+    "wof:lastmodified":1695886782,
     "wof:name":"Bal\u00e9",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",

--- a/data/890/453/941/890453941.geojson
+++ b/data/890/453/941/890453941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.575385,
-    "geom:area_square_m":6973545171.312457,
+    "geom:area_square_m":6973544928.95496,
     "geom:bbox":"0.424075,10.931,1.412905,11.940651",
     "geom:latitude":11.43192,
     "geom:longitude":0.884925,
@@ -216,12 +216,13 @@
         "qs_pg:id":575152,
         "wd:id":"Q1142059"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469052879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"00a8b1049da9e1f5741ecefdb9219335",
+    "wof:geomhash":"2600db4b851c4530d976fc9b7f2e535f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":890453941,
-    "wof:lastmodified":1690856959,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kompienga",
     "wof:parent_id":1108805685,
     "wof:placetype":"county",

--- a/data/890/453/945/890453945.geojson
+++ b/data/890/453/945/890453945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1328,
-    "geom:area_square_m":1602379976.551038,
+    "geom:area_square_m":1602380027.417648,
     "geom:bbox":"-2.082986,12.296546,-1.596757,12.905492",
     "geom:latitude":12.625726,
     "geom:longitude":-1.812717,
@@ -205,12 +205,13 @@
         "qs_pg:id":575154,
         "wd:id":"Q661376"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469052879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cc767d2669872b94407cf080e4dac85b",
+    "wof:geomhash":"299eeff228afefe3cd315a1a9344b8fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -220,7 +221,7 @@
         }
     ],
     "wof:id":890453945,
-    "wof:lastmodified":1690856960,
+    "wof:lastmodified":1695886782,
     "wof:name":"Kourw\u00e9ogo",
     "wof:parent_id":1108805691,
     "wof:placetype":"county",

--- a/data/890/453/947/890453947.geojson
+++ b/data/890/453/947/890453947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.257097,
-    "geom:area_square_m":3124610813.097392,
+    "geom:area_square_m":3124610961.36957,
     "geom:bbox":"-5.51892,10.28393,-4.937586,11.022831",
     "geom:latitude":10.61736,
     "geom:longitude":-5.266809,
@@ -208,12 +208,13 @@
         "qs_pg:id":575155,
         "wd:id":"Q977607"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469052879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bc3a617573018e6154a9f366223329fd",
+    "wof:geomhash":"0a448f917b5460e2f9b176707bf592df",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -223,7 +224,7 @@
         }
     ],
     "wof:id":890453947,
-    "wof:lastmodified":1690856959,
+    "wof:lastmodified":1695886782,
     "wof:name":"L\u00e9raba",
     "wof:parent_id":1108805703,
     "wof:placetype":"county",

--- a/data/890/453/949/890453949.geojson
+++ b/data/890/453/949/890453949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307837,
-    "geom:area_square_m":3694354543.221878,
+    "geom:area_square_m":3694353900.319696,
     "geom:bbox":"-2.662337,13.547055,-1.728954,14.29787",
     "geom:latitude":13.93736,
     "geom:longitude":-2.169411,
@@ -219,12 +219,13 @@
         "qs_pg:id":575156,
         "wd:id":"Q1142054"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469052879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"575c20bf940dde66f4f0e57e5e0554c1",
+    "wof:geomhash":"45e05d2a57c82f78a05b35d1f5048a2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -234,7 +235,7 @@
         }
     ],
     "wof:id":890453949,
-    "wof:lastmodified":1690856959,
+    "wof:lastmodified":1695886756,
     "wof:name":"Loroum",
     "wof:parent_id":1108805701,
     "wof:placetype":"county",

--- a/data/890/453/951/890453951.geojson
+++ b/data/890/453/951/890453951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.309684,
-    "geom:area_square_m":3735658969.657219,
+    "geom:area_square_m":3735658760.394866,
     "geom:bbox":"-3.435809,12.341425,-2.640279,12.980742",
     "geom:latitude":12.696497,
     "geom:longitude":-3.024324,
@@ -86,12 +86,13 @@
         "hasc:id":"BF.BO.NY",
         "qs_pg:id":575157
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BF",
     "wof:created":1469052879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f47fd8091eefd9fac427da8178a5d17",
+    "wof:geomhash":"83ed021f2ee2978cc01b1027f7832c61",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":890453951,
-    "wof:lastmodified":1636500515,
+    "wof:lastmodified":1695886756,
     "wof:name":"Nayala",
     "wof:parent_id":1108805707,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.